### PR TITLE
Removes 'vendor/homebrew-fork/global' requirement

### DIFF
--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH.unshift("#{HOMEBREW_PREFIX}/Library/Taps/caskroom/homebrew-cask/lib")
 
-require 'vendor/homebrew-fork/global'
 require 'hbc'
 
 CASKROOM = Hbc.caskroom


### PR DESCRIPTION
Fixes #8 