### PR TITLE
use new homebrew cask lib directory

### DIFF
--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift("#{HOMEBREW_PREFIX}/Library/Taps/caskroom/homebrew-cask/lib")
+$LOAD_PATH.unshift("#{HOMEBREW_PREFIX}/Library/Homebrew/cask/lib")
 
 require 'hbc'
 


### PR DESCRIPTION
`brew cu` fails with the following error
```
Error: cannot load such file -- hbc                                                                                                                                     
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/Taps/buo/homebrew-cask-upgrade/lib/extend/hbc.rb:5:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/Taps/buo/homebrew-cask-upgrade/lib/bcu.rb:1:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/Taps/buo/homebrew-cask-upgrade/cmd/brew-cu.rb:8:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/Homebrew/brew.rb:19:in `require?'
/usr/local/Library/Homebrew/brew.rb:93:in `<main>'
```
Using `"#{HOMEBREW_PREFIX}/Library/Homebrew/cask/lib"` instead of `"#{HOMEBREW_PREFIX}/Library/Taps/caskroom/homebrew-cask/lib"` fixes this.