### PR TITLE
Update formulae before checking outdated

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -31,6 +31,11 @@ module Bcu
 
   def self.process(args)
     options = parse(args)
+    begin
+      Hbc::CLI::Update.run
+    rescue SystemExit
+      $stdout
+    end
     Hbc.outdated(options.all).each do |app|
       next if options.dry_run
 


### PR DESCRIPTION
Cask updates only happen if the formulae that define them are updated. This PR runs the `brew cask update` (aka `brew update`) command before checking outdated casks. 