### PR TITLE
Replace deprecated `brew cask update`

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -32,7 +32,7 @@ module Bcu
   def self.process(args)
     options = parse(args)
     begin
-      Hbc::CLI::Update.run
+      system "#{HOMEBREW_BREW_FILE} update"
     rescue SystemExit
       $stdout
     end


### PR DESCRIPTION
Replace deprecated Hbc::CLI::Update.run (aka `brew cask update`) with system call to `brew update` (as located in the HOMEBREW_BREW_FILE env variable).

This should fix buo/homebrew-cask-upgrade#28