### PR TITLE
Change formulae update method

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -31,10 +31,11 @@ module Bcu
 
   def self.process(args)
     options = parse(args)
-    begin
-      Hbc::CLI::Update.run
-    rescue SystemExit
-      $stdout
+    result = Hbc::SystemCommand.run(HOMEBREW_BREW_FILE, args: ["update"], print_stderr: true, print_stdout: false)
+    # This is brittle but will only need to change if
+    # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/update.sh#L579 changes
+    if result.success? && result.to_s.chomp != "Already up-to-date."
+      puts "Updated formulae"
     end
     Hbc.outdated(options.all).each do |app|
       next if options.dry_run


### PR DESCRIPTION
`brew cask update` is being deprecated on 7/1/2017 so this PR preemptively changes the method we use to update formulae to the `Hbc::SystemCommand.run` method.

It also hides all the unnecessary output that `brew update` outputs to `$stdout` and only notifies if formulae have been updated.