### PR TITLE
Implement single cask upgrade feature

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -6,6 +6,7 @@ module Bcu
   def self.parse(args)
     options = OpenStruct.new
     options.all = false
+    options.cask = nil
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [options]"
@@ -16,6 +17,17 @@ module Bcu
 
       opts.on("--dry-run", "Print outdated apps without upgrading them") do
         options.dry_run = true
+      end
+
+      opts.on("--cask [CASK]", "Specify a single cask for upgrade") do |cask_name|
+        Hbc.each_installed(true) do |app|
+          options.cask = app if cask_name == app[:name]
+        end
+
+        if options.cask.nil?
+          puts "#{Tty.red}Cask \"#{cask_name}\" is not installed.#{Tty.reset}"
+          exit(1)
+        end
       end
 
       # `-h` is not available since the Homebrew hijacks it.

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -48,7 +48,8 @@ module Bcu
     rescue SystemExit
       $stdout
     end
-    Hbc.outdated(options.all).each do |app|
+
+    Hbc.outdated(options).each do |app|
       next if options.dry_run
 
       puts "==> Upgrading #{app[:name]} to #{app[:latest]}"

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -28,7 +28,7 @@ module Bcu
         end
 
         if options.cask.nil?
-          puts "#{Tty.red}Cask \"#{cask_name}\" is not installed.#{Tty.reset}"
+          onoe "#{Tty.red}Cask \"#{cask_name}\" is not installed.#{Tty.reset}"
           exit(1)
         end
       end
@@ -55,7 +55,7 @@ module Bcu
     Hbc.outdated(options).each do |app|
       next if options.dry_run
 
-      puts "==> Upgrading #{app[:name]} to #{app[:latest]}"
+      ohai "Upgrading #{app[:name]} to #{app[:latest]}"
 
       # Clean up the cask metadata container.
       system "rm -rf #{app[:cask].metadata_master_container_path}"

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -1,3 +1,6 @@
+$LOAD_PATH.unshift("#{HOMEBREW_REPOSITORY}/Library/Homebrew/cask/lib")
+
+require "hbc"
 require "extend/hbc"
 require "optparse"
 require "ostruct"

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -1,7 +1,3 @@
-$LOAD_PATH.unshift("#{HOMEBREW_REPOSITORY}/Library/Homebrew/cask/lib")
-
-require "hbc"
-
 CASKROOM = Hbc.caskroom
 
 module Hbc

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -5,15 +5,26 @@ require "hbc"
 CASKROOM = Hbc.caskroom
 
 module Hbc
-  def self.outdated(including_latest = false)
+  def self.outdated(options)
     outdated = []
     installed_count = Hbc.installed.length
     zero_pad = installed_count.to_s.length
-    each_installed do |app, i|
-      string_template = "(%0#{zero_pad}d/%d) #{app[:name]}: "
+    suppress_errors = !options.cask.nil? || false
+
+    each_installed(suppress_errors) do |app, i|
+      counter = "(%0#{zero_pad}d/%d)"
+
+      if options.cask
+        next unless options.cask[:name] == app[:name]
+        string_template = "#{app[:name]}: "
+      else
+        string_template = "#{counter} #{app[:name]}: "
+      end
+
+
       print format(string_template, i + 1, installed_count)
-      if including_latest && app[:latest] == "latest"
         puts "#{Tty.red}latest but forced to upgrade#{Tty.reset}"
+      if options.all && app[:latest] == "latest"
         outdated.push app
       elsif app[:installed].include? app[:latest]
         puts "#{Tty.green}up to date#{Tty.reset}"

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -13,12 +13,12 @@ module Hbc
 
     each_installed(suppress_errors) do |app, i|
       counter = "(%0#{zero_pad}d/%d)"
+      string_template = "#{app[:full_name]} (#{app[:name]}): "
 
       if options.cask
         next unless options.cask[:name] == app[:name]
-        string_template = "#{app[:name]}: "
       else
-        string_template = "#{counter} #{app[:name]}: "
+        string_template = "#{counter} #{string_template}"
       end
 
 
@@ -43,6 +43,7 @@ module Hbc
         yield({
           :cask => cask,
           :name => name.to_s,
+          :full_name => cask.name.first,
           :latest => cask.version.to_s,
           :installed => installed_versions(name),
         }, i)

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -25,7 +25,7 @@ module Hbc
     outdated
   end
 
-  def self.each_installed
+  def self.each_installed(suppress_errors = false)
     Hbc.installed.each_with_index do |name, i|
       begin
         cask = Hbc.load name.to_s
@@ -36,7 +36,7 @@ module Hbc
           :installed => installed_versions(name),
         }, i)
       rescue Hbc::CaskError => e
-        puts e
+        puts e unless suppress_errors
       end
     end
   end

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -19,13 +19,13 @@ module Hbc
 
 
       print format(string_template, i + 1, installed_count)
-        puts "#{Tty.red}latest but forced to upgrade#{Tty.reset}"
       if options.all && app[:latest] == "latest"
+        ohai "#{Tty.red}latest but forced to upgrade#{Tty.reset}"
         outdated.push app
       elsif app[:installed].include? app[:latest]
-        puts "#{Tty.green}up to date#{Tty.reset}"
+        ohai "#{Tty.green}up to date#{Tty.reset}"
       else
-        puts "#{Tty.red}#{app[:installed].join(", ")}#{Tty.reset} -> #{Tty.green}#{app[:latest]}#{Tty.reset}"
+        ohai "#{Tty.red}#{app[:installed].join(", ")}#{Tty.reset} -> #{Tty.green}#{app[:latest]}#{Tty.reset}"
         outdated.push app
       end
     end
@@ -44,7 +44,7 @@ module Hbc
           :installed => installed_versions(name),
         }, i)
       rescue Hbc::CaskError => e
-        puts e unless suppress_errors
+        opoo e unless suppress_errors
       end
     end
   end


### PR DESCRIPTION
This PR implements the ability to upgrade a single, named cask using the `--cask` flag. It respects the `--dry-run` flag and will tell you if the the cask you target is outdated or up to date.

My aim in this feature was to ease a pain point I have whenever JetBrains updates their IDEs. The downloads can be rather large and sometimes I only need to update one of them.

This PR also adds some nice stdout formatting from Homebrew's [`utils.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils.rb).