### PR TITLE
Refactored single cask install is now based on ARGV instead of --cask flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Upgrade outdated apps:
 brew cu
 ```
 
+Upgrade a specific app:
+
+```
+brew cu [CASK]
+```
+
 Options:
 
 ```

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -12,7 +12,7 @@ module Bcu
     options.cask = nil
 
     parser = OptionParser.new do |opts|
-      opts.banner = "Usage: brew cu [options]"
+      opts.banner = "Usage: brew cu [CASK] [options]"
 
       opts.on("-a", "--all", "Force upgrade outdated apps including the ones marked as latest") do
         options.all = true

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -22,17 +22,6 @@ module Bcu
         options.dry_run = true
       end
 
-      opts.on("--cask [CASK]", "Specify a single cask for upgrade") do |cask_name|
-        Hbc.each_installed(true) do |app|
-          options.cask = app if cask_name == app[:name]
-        end
-
-        if options.cask.nil?
-          onoe "#{Tty.red}Cask \"#{cask_name}\" is not installed.#{Tty.reset}"
-          exit(1)
-        end
-      end
-
       # `-h` is not available since the Homebrew hijacks it.
       opts.on_tail("--h", "Show this message") do
         puts opts
@@ -52,6 +41,8 @@ module Bcu
       $stdout
     end
 
+    options.cask = get_cask(args[0]) unless args[0].nil?
+
     Hbc.outdated(options).each do |app|
       next if options.dry_run
 
@@ -70,5 +61,22 @@ module Bcu
         end
       end
     end
+  end
+
+  def self.get_cask(cask_name)
+    cask = Hbc.get_installed_cask(cask_name)
+
+    if cask.nil?
+      onoe "#{Tty.red}Cask \"#{cask_name}\" is not installed.#{Tty.reset}"
+      exit(1)
+    end
+
+    {
+      cask: cask,
+      name: cask.to_s,
+      full_name: cask.name.first,
+      latest: cask.version.to_s,
+      installed: Hbc.installed_versions(cask.to_s),
+    }
   end
 end

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -49,6 +49,10 @@ module Hbc
     end
   end
 
+  def self.get_installed_cask(cask_name)
+    Hbc.installed.select {|name| name.to_s == cask_name }.first
+  end
+
   # Retrieves currently installed versions on the machine.
   def self.installed_versions(name)
     Dir["#{CASKROOM}/#{name}/*"].map { |e| File.basename e }


### PR DESCRIPTION
This PR continues work done in #32. Instead of having the `--cask` flag precede the specific cask you want to upgrade, `brew cu` now pulls the cask name from `ARGV`. 