### PR TITLE
Symlink command to be brew-cask external command

### DIFF
--- a/cmd/brewcask-upgrade.rb
+++ b/cmd/brewcask-upgrade.rb
@@ -1,0 +1,1 @@
+brew-cu.rb


### PR DESCRIPTION
While I was poking around the `homebrew` core, I discovered that `brew-cask` supports external commands in the form `brewcask-{command}`, [as shown in the command-line interface source](https://github.com/Homebrew/brew/blob/4d88cc4c41113be2d5bf11c11fa671c763705a64/Library/Homebrew/cask/lib/hbc/cli.rb#L115-L116).
This change takes advantage of that, and makes it easy to call this command using `brew cask upgrade`, as opposed to the current `brew cu`. And, built-in commands take precedence, meaning that, if `brew-cask` ever adds an upgrade command, this will fall back to the expected behavior, but preserve calling with `brew cu`.