### PR TITLE
Wrap `brew-cu` into noninteractive `brew-cask` upgrade command

### DIFF
--- a/cmd/brewcask-upgrade
+++ b/cmd/brewcask-upgrade
@@ -7,7 +7,7 @@ yes n | brew cu "${@}"
 
 if [ "${#}" = "0" ]
 then
-	#If no arguments, were passed to `brew-cu`, clear the last line of the terminal, which contains the prompt for user input
+	#If no arguments were passed to `brew-cu`, clear the last line of the terminal, which contains the prompt for user input
 	tput cr && tput el
 	
 	#Print a message explaining how to upgrade outdated casks in place of the interactive prompt

--- a/cmd/brewcask-upgrade
+++ b/cmd/brewcask-upgrade
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+#Create a noninteractive `brew-cask` external command by wrapping `brew-cu` (https://github.com/buo/homebrew-cask-upgrade)
+
+#Use `brew-cu` to list all outdated casks, but reject upgrading them if `brew-cu` wants interactive input, by feeding it a stream of "n"
+yes n | brew cu "${@}"
+
+if [ "${#}" = "0" ]
+then
+	#If no arguments, were passed to `brew-cu`, clear the last line of the terminal, which contains the prompt for user input
+	tput cr && tput el
+	
+	#Print a message explaining how to upgrade outdated casks in place of the interactive prompt
+	echo 'If there are outdated casks above, you can upgrade them by running `brew cask upgrade --yes`'
+fi


### PR DESCRIPTION
Following up on #42, this wraps `brew cu` into a shell script that ensures noninteractivity for use as an external command (i.e. `brew cask upgrade`).

Unfortunately, `brew cask update` is still a brew-cask internal command, meaning that there isn't an easy way to match the existing homebrew style exactly with `update` listing all outdated casks and `upgrade` actually upgrading them. This initial PR thus assumes that running `brew cask upgrade` means the user wants a list of outdated casks, and instructs them to run `brew cask upgrade --yes` if they actually want to upgrade them.

It accomplishes this by piping a stream of `n` into `brew cu`, which declines to upgrade the casks if `brew cu` is reading interactive input, or does nothing if any other options are passed to it, since `brew cu` is no longer reading the input piped to it. This also clears the last line of terminal output to prevent the interactive prompt from being displayed. This approach was taken as opposed to `grep`ing the output to allow preservation of colors (`brew cu` doesn't output colors when its stdout is a pipe), but leads to differing numbers of lines when the user has outdated casks or not.