### PR TITLE
Distinguish between apps that auto-update and those marked as latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Options:
 
 ```
 Usage: brew cu [CASK] [options]
-    -a, --all          Force upgrade outdated apps including those marked as latest and those that auto-update
+    -a, --all          Include apps that auto-update in the upgrade
         --cleanup      Cleans up cached downloads and tracker symlinks after updating
+    -f  --force        Include apps that are marked as latest (i.e. force-reinstall them)
     -y, --yes          Update all outdated apps; answer yes to updating packages
 ```
 

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -8,11 +8,14 @@
 #:    Upgrade a specific app.
 #:
 #:OPTIONS:
-#:    If `--all` or `-a` is passed, force upgrade outdated apps including those
-#:    marked as latest and those that auto-update.
+#:    If `--all` or `-a` is passed, include apps that auto-update in the
+#:    upgrade.
 #:
 #:    If `--cleanup` is passed, clean up cached downloads and tracker symlinks
 #:    after updating.
+#:
+#:    If `--force` or `-f` is passed, include apps that are marked as latest
+#:    (i.e. force-reinstall them).
 #:
 #:    If `--yes` or `-y` is passed, update all outdated apps; answer yes to
 #:    updating packages.

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -63,17 +63,22 @@ module Bcu
     end
 
     installed.each do |app|
-      if options.all && app[:version] == "latest"
+      version_latest = (app[:version] == "latest")
+
+      if options.force && options.all && version_latest && app[:auto_updates]
+        outdated.push app
+        state_info[app] = "forced to reinstall"
+      elsif options.force && version_latest && !app[:auto_updates]
+        outdated.push app
+        state_info[app] = "forced to reinstall"
+      elsif options.all && !version_latest && app[:auto_updates] && app[:outdated?]
         outdated.push app
         state_info[app] = "forced to upgrade"
-      elsif options.all && app[:auto_updates] && app[:outdated?]
-        outdated.push app
-        state_info[app] = "forced to upgrade"
-      elsif !options.all && app[:auto_updates]
-        state_info[app] = "ignored"
-      elsif app[:outdated?]
+      elsif !version_latest && !app[:auto_updates] && app[:outdated?]
         outdated.push app
         state_info[app] = "outdated"
+      elsif version_latest || app[:outdated?]
+        state_info[app] = "ignored"
       elsif app[:cask].nil?
         state_info[app] = "no cask available"
       end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -7,6 +7,7 @@ module Bcu
   def self.parse!(args)
     options = OpenStruct.new
     options.all = false
+    options.force = false
     options.cask = nil
     options.cleanup = false
     options.dry_run = true
@@ -14,12 +15,16 @@ module Bcu
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
 
-      opts.on("-a", "--all", "Force upgrade outdated apps including those marked as latest and those that auto-update") do
+      opts.on("-a", "--all", "Include apps that auto-update in the upgrade") do
         options.all = true
       end
 
       opts.on("--cleanup", "Cleans up cached downloads and tracker symlinks after updating") do
         options.cleanup = true
+      end
+
+      opts.on("-f", "--force", "Include apps that are marked as latest (i.e. force-reinstall them)") do
+        options.force = true
       end
 
       opts.on("-y", "--yes", "Update all outdated apps; answer yes to updating packages") do


### PR DESCRIPTION
As a follow-up to #49, this adds a separation between apps that auto-update and those that are marked as latest through new command line options: `--all` now includes apps that auto-update, while `--force` is (additionally or exclusively) required for apps marked as latest.
     
The rationale behind this is to allow upgrades of apps that auto-update without always reinstalling such marked as latest. The wish for that has also been [brought up](https://github.com/caskroom/homebrew-cask/issues/29301#issuecomment-275172964) by @leipert in the discussion on caskroom/homebrew-cask#29301.
I can see three major reasons why one would want this:

* Bringing all apps (or at least as many as possible) to a current version without having to launch each of them
* Disallowing apps to "call home" through update checks for privacy concerns
* Using a non-admin user account for daily work, such that apps cannot necessarily write themselves

As for the command line options, the semantics of `--all` are of course changed yet again, but I consider this one the most intuitive variant. However, I care much less for the names than I do for the feature in general 🙂.