### PR TITLE
Auto-update Homebrew, taps, and formulae before checking outdated apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ Options:
 
 ```
 Usage: brew cu [CASK] [options]
-    -a, --all          Include apps that auto-update in the upgrade
-        --cleanup      Cleans up cached downloads and tracker symlinks after updating
-    -f  --force        Include apps that are marked as latest (i.e. force-reinstall them)
-    -y, --yes          Update all outdated apps; answer yes to updating packages
+    -a, --all             Include apps that auto-update in the upgrade.
+        --cleanup         Cleans up cached downloads and tracker symlinks after
+                          updating.
+    -f  --force           Include apps that are marked as latest
+                          (i.e. force-reinstall them).
+        --no-brew-update  Prevent auto-update of Homebrew, taps, and fomulae
+                          before checking outdated apps.
+    -y, --yes             Update all outdated apps; answer yes to updating packages.
 ```
 
 Display usage instructions:

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -16,6 +16,9 @@
 #:    If `--force` or `-f` is passed, include apps that are marked as latest
 #:    (i.e. force-reinstall them).
 #:
+#:    If `--no-brew-update` is passed, prevent auto-update of Homebrew, taps,
+#:    and fomulae before checking outdated apps.
+#:
 #:    If `--yes` or `-y` is passed, update all outdated apps; answer yes to
 #:    updating packages.
 

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -13,12 +13,13 @@ module Bcu
     puts "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
     puts "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
 
-    puts
+    ohai "Updating Homebrew"
+    puts Hbc.brew_update
+
     ohai "Finding outdated apps"
     outdated, state_info = find_outdated_apps
     return if outdated.empty?
 
-    puts
     ohai "Found outdated apps"
     print_app_table(outdated, state_info)
 

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -13,8 +13,10 @@ module Bcu
     puts "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
     puts "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
 
-    ohai "Updating Homebrew"
-    puts Hbc.brew_update
+    unless options.no_brew_update
+      ohai "Updating Homebrew"
+      puts Hbc.brew_update
+    end
 
     ohai "Finding outdated apps"
     outdated, state_info = find_outdated_apps

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -11,6 +11,7 @@ module Bcu
     options.cask = nil
     options.cleanup = false
     options.dry_run = true
+    options.no_brew_update = false
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -25,6 +26,10 @@ module Bcu
 
       opts.on("-f", "--force", "Include apps that are marked as latest (i.e. force-reinstall them)") do
         options.force = true
+      end
+
+      opts.on("--no-brew-update", "Prevent auto-update of Homebrew, taps, and fomulae before checking outdated apps") do
+        options.no_brew_update = true
       end
 
       opts.on("-y", "--yes", "Update all outdated apps; answer yes to updating packages") do

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -47,4 +47,8 @@ module Hbc
   def self.installed_versions(token)
     Dir["#{CASKROOM}/#{token}/*"].map { |e| File.basename e }
   end
+
+  def self.brew_update
+    Hbc::SystemCommand.run(HOMEBREW_BREW_FILE, args: ["update"], print_stderr: true, print_stdout: false)
+  end
 end


### PR DESCRIPTION
It would be a good idea to bring this feature back (#37) since `brew install` will trigger `brew update` by default.

In the same manner `brew cu` will trigger `brew update` by default, but I added `--no-brew-update` option for users who want to run `brew update` manually.

This PR fixes #62.

