### PR TITLE
Add quiet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage: brew cu [CASK] [options]
         --no-brew-update  Prevent auto-update of Homebrew, taps, and fomulae
                           before checking outdated apps.
     -y, --yes             Update all outdated apps; answer yes to updating packages.
+    -q, --quiet           Do not show information about installed apps or current options.
 ```
 
 Display usage instructions:

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -21,6 +21,9 @@
 #:
 #:    If `--yes` or `-y` is passed, update all outdated apps; answer yes to
 #:    updating packages.
+#:
+#:    If `--quiet` or `-q` is passed, do not show information about installed
+#:    apps or current options.
 
 require "pathname"
 

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -9,9 +9,11 @@ module Bcu
   def self.process(args)
     parse!(args)
 
-    ohai "Options"
-    puts "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
-    puts "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
+    unless options.quiet
+      ohai "Options"
+      puts "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
+      puts "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
+    end
 
     unless options.no_brew_update
       ohai "Updating Homebrew"
@@ -19,8 +21,11 @@ module Bcu
     end
 
     ohai "Finding outdated apps"
-    outdated, state_info = find_outdated_apps
-    return if outdated.empty?
+    outdated, state_info = find_outdated_apps(options.quiet)
+    if outdated.empty?
+      puts "No outdated apps found." if options.quiet
+      return
+    end
 
     ohai "Found outdated apps"
     print_app_table(outdated, state_info)
@@ -54,7 +59,7 @@ module Bcu
     Hbc::CLI::Cleanup.run if options.cleanup
   end
 
-  def self.find_outdated_apps
+  def self.find_outdated_apps(quiet)
     outdated = []
     state_info = Hash.new("")
 
@@ -90,7 +95,7 @@ module Bcu
       end
     end
 
-    print_app_table(installed, state_info)
+    print_app_table(installed, state_info) unless quiet
 
     [outdated, state_info]
   end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -12,6 +12,7 @@ module Bcu
     options.cleanup = false
     options.dry_run = true
     options.no_brew_update = false
+    options.quiet = false
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -34,6 +35,10 @@ module Bcu
 
       opts.on("-y", "--yes", "Update all outdated apps; answer yes to updating packages") do
         options.dry_run = false
+      end
+
+      opts.on("-q", "--quiet", "Do not show information about installed apps or current options") do
+        options.quiet = true
       end
     end
 


### PR DESCRIPTION
Closes #75.

I verified this works by running:
* `brew cu -h` and confirming that help shows. 
* `brew cu -aq` and confirming that options don't show.
* `brew cu -aq` and confirming that when there are no outdated apps, a message is shown.

I did not have any outdated apps, so I could not confirm that quiet behavior is correct, but I didn't touch that code, so it should be fine.