### PR TITLE
correct misspellings of "fomulae" to "formulae"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage: brew cu [CASK] [options]
                           updating.
     -f  --force           Include apps that are marked as latest
                           (i.e. force-reinstall them).
-        --no-brew-update  Prevent auto-update of Homebrew, taps, and fomulae
+        --no-brew-update  Prevent auto-update of Homebrew, taps, and formulae
                           before checking outdated apps.
     -y, --yes             Update all outdated apps; answer yes to updating packages.
     -q, --quiet           Do not show information about installed apps or current options.

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -17,7 +17,7 @@
 #:    (i.e. force-reinstall them).
 #:
 #:    If `--no-brew-update` is passed, prevent auto-update of Homebrew, taps,
-#:    and fomulae before checking outdated apps.
+#:    and formulae before checking outdated apps.
 #:
 #:    If `--yes` or `-y` is passed, update all outdated apps; answer yes to
 #:    updating packages.

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -29,7 +29,7 @@ module Bcu
         options.force = true
       end
 
-      opts.on("--no-brew-update", "Prevent auto-update of Homebrew, taps, and fomulae before checking outdated apps") do
+      opts.on("--no-brew-update", "Prevent auto-update of Homebrew, taps, and formulae before checking outdated apps") do
         options.no_brew_update = true
       end
 


### PR DESCRIPTION
"formulae" was misspelt as "fomulae" in three different places. :)