### PR TITLE
Sorting installed apps update

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -110,7 +110,7 @@ module Bcu
     thead << Formatter::TableColumn.new(value: "Result", align: "center")
     table = [thead]
 
-    apps.sort_by { |a| a[:token] }.each_with_index do |app, i|
+    apps.each_with_index do |app, i|
       if state_info[app][0, 6] == "forced"
         color = "yellow"
         result = "[ FORCED ]"

--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -6,7 +6,7 @@ module Hbc
     # it raises errors while iterating and stops.
     installed = Dir["#{CASKROOM}/*"].map { |e| File.basename e }
 
-    installed.map do |token|
+    installed = installed.map do |token|
       versions = installed_versions(token)
       begin
         cask = load_cask(token)
@@ -31,6 +31,8 @@ module Hbc
         }
       end
     end
+
+    installed.sort_by { |a| a[:token] }
   end
 
   # See: https://github.com/buo/homebrew-cask-upgrade/issues/43


### PR DESCRIPTION
In the previous fix, I made a mistake, that the apps were sorted only in the table, but all the other actions (like update itself) were run in the "wrong" order. That caused some troubles (i.e. that `virtualbox-extension-pack` was being installed before `virtualbox` itself => installation crash).

I have moved the sorting so then every time you call `Hbc.installed_apps` you will get them sorted based on a token.