### PR TITLE
Fixes #95

### DIFF
--- a/lib/extend/hbc.rb
+++ b/lib/extend/hbc.rb
@@ -1,4 +1,4 @@
-CASKROOM = Hbc.caskroom
+CASKROOM = Hbc::Caskroom.path
 
 module Hbc
   def self.installed_apps


### PR DESCRIPTION
Change Caskroom path retrieval due to changes in hbc/locations.rb
```
Hbc.caskroom was changed to Hbc::Caskroom.path here https://github.com/Homebrew/brew/commit/3d423b0587d54029cc60616d506318425c22e7a4#diff-7251741d14e538114958333ecce1e184L9
```