### PR TITLE
Fixes #100 Fixing `brew update` result message

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -17,7 +17,7 @@ module Bcu
 
     unless options.no_brew_update
       ohai "Updating Homebrew"
-      puts Hbc.brew_update
+      puts Hbc.brew_update.stdout
     end
 
     ohai "Finding outdated apps"


### PR DESCRIPTION
Result of brew update command has been changed to an object, therefore the script has to be updated to use the `stdout`