### PR TITLE
Using system brew cleanup instead of deprecated brew cask cleanup

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -55,8 +55,8 @@ module Bcu
         end
       end
     end
-
-    Hbc::CLI::Cleanup.run if options.cleanup
+    
+    system "brew cleanup" if options.cleanup
   end
 
   def self.find_outdated_apps(quiet)


### PR DESCRIPTION
`brew cask cleanup` is deprecated now, will be disabled on 2018-09-30 and the base `brew cleanup` should be used.

Updated the `--cleanup` option to use `brew cleanup` system command.