### PR TITLE
add --no-quarantine option for brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Usage: brew cu [CASK] [options]
                           before checking outdated apps.
     -y, --yes             Update all outdated apps; answer yes to updating packages.
     -q, --quiet           Do not show information about installed apps or current options.
+    --no-quarantine       Pass --no-quarantine option to `brew cask install`.
 ```
 
 Display usage instructions:

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -46,7 +46,7 @@ module Bcu
       system "rm -rf #{app[:cask].metadata_master_container_path}"
 
       # Force to install the latest version.
-      system "brew cask install #{app[:token]} --force"
+      system "brew cask install #{options.install_options} #{app[:token]} --force"
 
       # Remove the old versions.
       app[:current].each do |version|

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -13,6 +13,7 @@ module Bcu
     options.dry_run = true
     options.no_brew_update = false
     options.quiet = false
+    options.install_options = ""
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -39,6 +40,10 @@ module Bcu
 
       opts.on("-q", "--quiet", "Do not show information about installed apps or current options") do
         options.quiet = true
+      end
+
+      opts.on("--no-quarantine", "Add --no-quarantine option to install command, see brew cask documentation") do
+        options.install_options += " --no-quarantine"
       end
     end
 


### PR DESCRIPTION
MacOS 10.13.6 can issue warning on Apps installed by brew cask. New option --no-quarantine remove quarantine xattr for installed apps.