### PR TITLE
Adding support for multiple casks as arguments and wildcard search

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -65,10 +65,25 @@ module Bcu
 
     installed = Cask.installed_apps
 
-    if options.cask
-      installed = installed.select { |app| app[:token] == options.cask }
+    unless options.casks.empty?
+      installed = installed.select do |app| 
+        found = false
+        options.casks.each do |arg| 
+          found = true if app[:token] == arg || (arg.end_with?('*') && app[:token].start_with?(arg.slice(0..-2)))
+        end
+        found
+      end
+
       if installed.empty?
-        onoe "#{Tty.red}Cask \"#{options.cask}\" is not installed.#{Tty.reset}"
+        if options.casks.length == 1
+          if options.casks[0].end_with? '*'
+            onoe "#{Tty.red}No Cask matching \"#{options.casks[0]}\" is installed.#{Tty.reset}"
+          else
+            onoe "#{Tty.red}Cask \"#{options.casks[0]}\" is not installed.#{Tty.reset}"
+          end
+        else 
+          onoe "#{Tty.red}No casks matching your arguments found.#{Tty.reset}"
+        end
         exit(1)
       end
     end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -8,7 +8,7 @@ module Bcu
     options = OpenStruct.new
     options.all = false
     options.force = false
-    options.cask = nil
+    options.casks = nil
     options.cleanup = false
     options.dry_run = true
     options.no_brew_update = false
@@ -49,7 +49,7 @@ module Bcu
 
     parser.parse!(args)
 
-    options.cask = args[0]
+    options.casks = args
 
     self.options = options
   end


### PR DESCRIPTION
Resolves #126 

This is adding support for multiple arguments in the `cu` command as folows:
```bash
>> brew cu -acf flash-npapi flash-ppapi                                                                                                                                                                                                        1 ↵  10018  10:47:51
==> Options
Include auto-update (-a): true
Include latest (-f): true
==> Updating Homebrew
Already up-to-date.
==> Finding outdated apps
     Cask         Current     Latest      A/U    Result
1/2  flash-npapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]
2/2  flash-ppapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]
==> Found outdated apps
     Cask         Current     Latest      A/U    Result
1/2  flash-npapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]
2/2  flash-ppapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]

Do you want to upgrade 2 apps [y/N]?
```

Also added support for prefix search, i.e. :
```bash
>> brew cu -acf flash-\*                                                                                                                                                                                                                           10019  10:52:58
==> Options
Include auto-update (-a): true
Include latest (-f): true
==> Updating Homebrew
Already up-to-date.
==> Finding outdated apps
     Cask         Current     Latest      A/U    Result
1/2  flash-npapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]
2/2  flash-ppapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]
==> Found outdated apps
     Cask         Current     Latest      A/U    Result
1/2  flash-npapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]
2/2  flash-ppapi  31.0.0.122  31.0.0.148   Y   [ FORCED ]

Do you want to upgrade 2 apps [y/N]?
```

Enjoy! 🙂 