### PR TITLE
Add version pinning functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+pins

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.gem
-pins
+pinned

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Usage: brew cu [CASK] [options]
     -y, --yes             Update all outdated apps; answer yes to updating packages.
     -q, --quiet           Do not show information about installed apps or current options.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
+        --pins            Print all pinned apps
+        --pin APP         Pin the current app version
+        --unpin APP       Unpin the current app version
 ```
 
 Display usage instructions:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Usage: brew cu [CASK] [options]
     -y, --yes             Update all outdated apps; answer yes to updating packages.
     -q, --quiet           Do not show information about installed apps or current options.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
-        --pins            Print all pinned apps
+        --pinned          Print all pinned apps
         --pin APP         Pin the current app version
         --unpin APP       Unpin the current app version
 ```

--- a/README.md
+++ b/README.md
@@ -55,13 +55,18 @@ Usage: brew cu [CASK] [options]
     -q, --quiet           Do not show information about installed apps or current options.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
         --pinned          Print all pinned apps
-        --pin APP         Pin the current app version
-        --unpin APP       Unpin the current app version
+        --pin CASK         Pin the current app version
+        --unpin CASK       Unpin the current app version
 ```
 
 Display usage instructions:
 ```sh
 brew help cu
 ```
+
+### Version pinning
+
+Pinned apps will not be updated by `brew cu` until they are unpinned.
+NB: version pinning in `brew cu` will not prevent `brew cask upgrade` from updating pinned apps.
 
 [![asciicast](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW.png)](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Usage: brew cu [CASK] [options]
     -q, --quiet           Do not show information about installed apps or current options.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
         --pinned          Print all pinned apps
-        --pin CASK         Pin the current app version
-        --unpin CASK       Unpin the current app version
+        --pin CASK        Pin the current app version
+        --unpin CASK      Unpin the current app version
 ```
 
 Display usage instructions:

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -27,6 +27,13 @@
 #:
 #:    If `--no-quarantine` is passed, that option will be added to the install
 #:    command (see `man brew-cask` for reference)
+#:
+#:    If `--pins` is passed, print all pinned apps
+#:
+#:    If `--pin APP` is passed, pin the current app version
+#:
+#:    If `--unpin APP` is passed, unpin the current app version
+#:
 
 require "pathname"
 

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -30,9 +30,9 @@
 #:
 #:    If `--pinned` is passed, print all pinned apps
 #:
-#:    If `--pin APP` is passed, pin the current app version
+#:    If `--pin CASK` is passed, pin the current app version
 #:
-#:    If `--unpin APP` is passed, unpin the current app version
+#:    If `--unpin CASK` is passed, unpin the current app version
 #:
 
 require "pathname"

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -28,7 +28,7 @@
 #:    If `--no-quarantine` is passed, that option will be added to the install
 #:    command (see `man brew-cask` for reference)
 #:
-#:    If `--pins` is passed, print all pinned apps
+#:    If `--pinned` is passed, print all pinned apps
 #:
 #:    If `--pin APP` is passed, pin the current app version
 #:

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -4,8 +4,8 @@ require "bcu/options"
 require "cask/all"
 require "extend/formatter"
 require "extend/cask"
-require 'fileutils'
-require 'set'
+require "fileutils"
+require "set"
 
 PINS_FILE = File.expand_path(File.dirname(__FILE__) + "/../pins")
 
@@ -87,7 +87,6 @@ module Bcu
     return if options.dry_run
 
     outdated.each do |app|
-
       ohai "Upgrading #{app[:token]} to #{app[:version]}"
 
       # Clean up the cask metadata container.

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -49,7 +49,7 @@ module Bcu
         options.install_options += " --no-quarantine"
       end
 
-      opts.on("--pins", "List pinned apps") do
+      opts.on("--pinned", "List pinned apps") do
         options.list_pins = true
       end
 

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -14,7 +14,7 @@ module Bcu
     options.no_brew_update = false
     options.quiet = false
     options.install_options = ""
-    options.list_pins = false
+    options.list_pinned = false
     options.pin = nil
     options.unpin = nil
 
@@ -50,15 +50,15 @@ module Bcu
       end
 
       opts.on("--pinned", "List pinned apps") do
-        options.list_pins = true
+        options.list_pinned = true
       end
 
-      opts.on("--pin APP", "App to pin") do |app|
-        options.pin = app
+      opts.on("--pin CASK", "Cask to pin") do |cask|
+        options.pin = cask
       end
 
-      opts.on("--unpin APP", "App to unpin") do |app|
-        options.unpin = app
+      opts.on("--unpin CASK", "Cask to unpin") do |cask|
+        options.unpin = cask
       end
     end
 

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -49,15 +49,15 @@ module Bcu
         options.install_options += " --no-quarantine"
       end
 
-      opts.on("--pins", "List pinned casks") do
+      opts.on("--pins", "List pinned apps") do
         options.list_pins = true
       end
 
-      opts.on("--pin CASK", "Cask to pin") do |app|
+      opts.on("--pin APP", "App to pin") do |app|
         options.pin = app
       end
 
-      opts.on("--unpin CASK", "Cask to unpin") do |app|
+      opts.on("--unpin APP", "App to unpin") do |app|
         options.unpin = app
       end
     end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -14,6 +14,9 @@ module Bcu
     options.no_brew_update = false
     options.quiet = false
     options.install_options = ""
+    options.list_pins = false
+    options.pin = nil
+    options.unpin = nil
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -44,6 +47,18 @@ module Bcu
 
       opts.on("--no-quarantine", "Add --no-quarantine option to install command, see brew cask documentation for additional information") do
         options.install_options += " --no-quarantine"
+      end
+
+      opts.on("--pins", "List pinned casks") do
+        options.list_pins = true
+      end
+
+      opts.on("--pin CASK", "Cask to pin") do |app|
+        options.pin = app
+      end
+
+      opts.on("--unpin CASK", "Cask to unpin") do |app|
+        options.unpin = app
       end
     end
 

--- a/lib/extend/formatter.rb
+++ b/lib/extend/formatter.rb
@@ -157,6 +157,9 @@ module Formatter
         color = "default"
         result = "[  PASS  ]"
       end
+    elsif state_info[app] == "pinned"
+      color = "yellow"
+      result = "[ PINNED ]"
     elsif state_info[app] == "outdated"
       color = "red"
       result = "[OUTDATED]"

--- a/lib/extend/formatter.rb
+++ b/lib/extend/formatter.rb
@@ -146,7 +146,10 @@ module Formatter
   end
 
   def formatting_for_app(state_info, app, options)
-    if state_info[app][0, 6] == "forced"
+    if state_info[app] == "pinned"
+      color = "cyan"
+      result = "[ PINNED ]"
+    elsif state_info[app][0, 6] == "forced"
       color = "yellow"
       result = "[ FORCED ]"
     elsif app[:auto_updates]
@@ -157,9 +160,6 @@ module Formatter
         color = "default"
         result = "[  PASS  ]"
       end
-    elsif state_info[app] == "pinned"
-      color = "yellow"
-      result = "[ PINNED ]"
     elsif state_info[app] == "outdated"
       color = "red"
       result = "[OUTDATED]"


### PR DESCRIPTION
# Why

I found myself needing this when I didn't want to update `java8`.

This PR resolves #108, resolves #93, resolves #90, resolves #72

# Not included in this PR

Currently you can pin casks that are not installed. So you can pin `asdasfsadasd`

# Usage

```
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --help
...

OPTIONS:
...
    If --pinned is passed, print all pinned apps

    If --pin CASK is passed, pin the current app version

    If --unpin CASK is passed, unpin the current app version
```

# Example usage

```
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --pinned
java8
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --pin firefox
Pinned: firefox
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --pin firefox
Already pinned: firefox
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --pinned
java8
firefox
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --unpin firefox
Unpinned: firefox
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --unpin firefox
Not pinned: firefox
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --pinned
java8
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu
==> Options
Include auto-update (-a): false
Include latest (-f): false
==> Updating Homebrew
Already up-to-date.
==> Finding outdated apps
       Cask                    Current                  Latest                A/U    Result
...
 8/19  java8                   1.8.0_192-b12,750e1c...  8.202.03,07_nov_2018       [ PINNED ]
...
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu --unpin java8
Unpinned: java8
gary@v1020-wn-17-117:~/pg/homebrew-cask-upgrade (master)$ brew cu
==> Options
Include auto-update (-a): false
Include latest (-f): false
==> Updating Homebrew
Already up-to-date.
==> Finding outdated apps
       Cask                    Current                  Latest                A/U    Result
...
 8/19  java8                   1.8.0_192-b12,750e1c...  8.202.03,07_nov_2018       [OUTDATED]
...
==> Found outdated apps
     Cask   Current                                         Latest                A/U    Result
1/1  java8  1.8.0_192-b12,750e1c8617c5452694857ad95c3ee230  8.202.03,07_nov_2018       [OUTDATED]

Do you want to upgrade 1 app [y/N]? ^C
```