### PR TITLE
Interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ brew cu [CASK]
 While running the `brew cu` command without any other further options, the script automatically runs `brew update` to get
 latest versions of all the installed casks (this can be disabled, see options below).
 
+It is also possible to use `*` to instal multiple casks at once, i.e. `brew cu flash-*` to install all casks starting with `flash-` prefix.
+
+[![asciicast](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW.png)](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW)
+
 ### Apps with auto-update
 
 If the app has the auto update functionality (they ask you themselves, if you want to upgrade them), they are not
@@ -57,6 +61,7 @@ Usage: brew cu [CASK] [options]
         --pinned          Print all pinned apps
         --pin CASK        Pin the current app version
         --unpin CASK      Unpin the current app version
+    -i, --interactive     Running update in interactive mode    
 ```
 
 Display usage instructions:
@@ -64,9 +69,15 @@ Display usage instructions:
 brew help cu
 ```
 
+### Interactive mode
+
+When using interactive mode (by adding `--interactive` argument or confirming app installation with `i`) will trigger per-cask confirmation.
+For every cask it is then possible to use following options:
+- `y` will install the current cask update
+- `N` will skip the installation of current cask
+- `p` will pin the current version of the cask (see [version pinning](#version-pinning))
+
 ### Version pinning
 
 Pinned apps will not be updated by `brew cu` until they are unpinned.
 NB: version pinning in `brew cu` will not prevent `brew cask upgrade` from updating pinned apps.
-
-[![asciicast](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW.png)](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW)

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -4,9 +4,10 @@
 #:    Upgrade every outdated app installed by `brew cask`.
 #:
 #:  * `cu` cask [`options`]
-#:    Upgrade a specific app.
+#:    Upgrade a specific app. You can use star to include more apps (`brew cu flash-***`)
+#:    to upgrade all flash related casks (might require escaping `brew cu flash-\*`).
 #:
-#:OPTIONS:
+#:`OPTIONS`:
 #:    If `--all` or `-a` is passed, include apps that auto-update in the
 #:    upgrade.
 #:
@@ -33,6 +34,17 @@
 #:    If `--pin CASK` is passed, pin the current app version
 #:
 #:    If `--unpin CASK` is passed, unpin the current app version
+#:
+#:`INTERACTIVE MODE`:
+#:    After listing casks to upgrade you want those casks to be upgraded.
+#:    By using the option `i` you will step into an interactive mode.
+#:
+#:    In the `interactive` mode you will be asked for every single app separately
+#:        `y` will upgrade the app
+#:        `p` will pin the app so it will not prompt you again, unless you unpin it
+#:        `N` will skip the app upgrade
+#:
+#:    All unknown options will be considered as `N`
 #:
 
 require "pathname"

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -51,7 +51,7 @@ module Bcu
     printf "\n"
 
     unless options.interactive || options.force_yes
-      printf "Do you want to upgrade %d app%s [y/i/N]? ", outdated.length, (outdated.length > 1) ? "s" : ""
+      printf "Do you want to upgrade %d app%s or enter [i]nteractive mode [y/i/N]? ", outdated.length, (outdated.length > 1) ? "s" : ""
       input = STDIN.gets.strip
 
       if input.casecmp("i").zero?
@@ -67,7 +67,7 @@ module Bcu
     outdated.each do |app|
       if options.interactive
         formatting = Formatter.formatting_for_app(state_info, app, options)
-        printf 'Do you want to upgrade "%s" [y/p/N]? ', Formatter.colorize(app[:token], formatting[0])
+        printf 'Do you want to upgrade "%s" or [p]in it to exclude it from updates [y/p/N]? ', Formatter.colorize(app[:token], formatting[0])
         input = STDIN.gets.strip
 
         if input.casecmp("p").zero?

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -10,13 +10,14 @@ module Bcu
     options.force = false
     options.casks = nil
     options.cleanup = false
-    options.dry_run = true
+    options.force_yes = false
     options.no_brew_update = false
     options.quiet = false
     options.install_options = ""
     options.list_pinned = false
     options.pin = nil
     options.unpin = nil
+    options.interactive = false
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -38,7 +39,11 @@ module Bcu
       end
 
       opts.on("-y", "--yes", "Update all outdated apps; answer yes to updating packages") do
-        options.dry_run = false
+        options.force_yes = true
+      end
+
+      opts.on("-i", "--interactive", "Use interactive mode while installing") do
+        options.interactive = true
       end
 
       opts.on("-q", "--quiet", "Do not show information about installed apps or current options") do

--- a/lib/extend/formatter.rb
+++ b/lib/extend/formatter.rb
@@ -117,6 +117,7 @@ module Formatter
 
   def truncate(string, len: 10, suffix: "...")
     return string if string.length <= len
+
     "#{string[0, len - suffix.length]}#{suffix}"
   end
 


### PR DESCRIPTION
Introducing interactive mode to installing the apps. That could be achieved through `--interactive` argument when running `brew cu` command or by using `i` when asked if apps should be updated.

Resolves #135 
Resolves #134