### PR TITLE
Added --report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Usage: brew cu [CASK] [options]
         --pinned          Print all pinned apps
         --pin CASK        Pin the current app version
         --unpin CASK      Unpin the current app version
-    -i, --interactive     Running update in interactive mode    
+    -i, --interactive     Running update in interactive mode
+    -r, --report          Return list of outdated apps and quit without performing updates
 ```
 
 Display usage instructions:

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -26,6 +26,9 @@
 #:    If `--quiet` or `-q` is passed, do not show information about installed
 #:    apps or current options.
 #:
+#:    If `--report` or `-r` is passed, show information about outdated
+#:    apps and quit without performing updates.
+#:
 #:    If `--no-quarantine` is passed, that option will be added to the install
 #:    command (see `man brew-cask` for reference)
 #:

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -40,15 +40,19 @@ module Bcu
     end
 
     ohai "Finding outdated apps"
-    outdated, state_info = find_outdated_apps(options.quiet)
+    outdated, state_info = find_outdated_apps(options.quiet, options.report)
     if outdated.empty?
-      puts "No outdated apps found." if options.quiet
+      puts "No outdated apps found." if options.quiet || options.report
       return
     end
 
     ohai "Found outdated apps"
     Formatter.print_app_table(outdated, state_info, options)
     printf "\n"
+
+    if options.report
+      return
+    end
 
     unless options.interactive || options.force_yes
       printf "Do you want to upgrade %d app%s or enter [i]nteractive mode [y/i/N]? ", outdated.length, (outdated.length > 1) ? "s" : ""
@@ -95,7 +99,7 @@ module Bcu
     system "brew cleanup" if options.cleanup && cleanup_necessary
   end
 
-  def self.find_outdated_apps(quiet)
+  def self.find_outdated_apps(quiet, report)
     outdated = []
     state_info = Hash.new("")
 
@@ -139,7 +143,7 @@ module Bcu
       end
     end
 
-    Formatter.print_app_table(installed, state_info, options) unless quiet
+    Formatter.print_app_table(installed, state_info, options) unless quiet || report
 
     [outdated, state_info]
   end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -18,6 +18,7 @@ module Bcu
     options.pin = nil
     options.unpin = nil
     options.interactive = false
+    options.report = false
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -64,6 +65,10 @@ module Bcu
 
       opts.on("--no-quarantine", "Add --no-quarantine option to install command, see brew cask documentation for additional information") do
         options.install_options += " --no-quarantine"
+      end
+
+      opts.on("-r", "--report", "Return list of outdated apps and quit without performing updates") do
+        options.report = true
       end
 
       opts.on("--pinned", "List pinned apps") do


### PR DESCRIPTION
Adding the `-r` or `--report` option returns a list of outdated apps, then quits without performing an update. Can be used in conjunction with the `-f` and `-a` options.