### PR TITLE
Add --verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Usage: brew cu [CASK] [options]
                           before checking outdated apps.
     -y, --yes             Update all outdated apps; answer yes to updating packages.
     -q, --quiet           Do not show information about installed apps or current options.
+    -v, --verbose         Make output more verbose.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
         --pinned          Print all pinned apps. See also `pin`.
         --pin CASK        Pin the current app version, preventing it from being 

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -26,6 +26,8 @@
 #:    If `--quiet` or `-q` is passed, do not show information about installed
 #:    apps or current options.
 #:
+#:    If `--verbose` or `-v` is passed, make output more verbose.
+#:
 #:    If `--no-quarantine` is passed, that option will be added to the install
 #:    command (see `man brew-cask` for reference)
 #:

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -36,7 +36,7 @@ module Bcu
 
     unless options.no_brew_update
       ohai "Updating Homebrew"
-      puts Cask.brew_update.stdout
+      puts Cask.brew_update(options.verbose).stdout
     end
 
     ohai "Finding outdated apps"
@@ -64,6 +64,13 @@ module Bcu
     # In interactive flow we're not sure if we need to clean up
     cleanup_necessary = !options.interactive
 
+    # Create verbose flag
+    if options.verbose
+      verbose_flag = "--verbose"
+    else
+      verbose_flag = ""
+    end
+
     outdated.each do |app|
       if options.interactive
         formatting = Formatter.formatting_for_app(state_info, app, options)
@@ -82,7 +89,7 @@ module Bcu
       system "rm -rf #{app[:cask].metadata_master_container_path}"
 
       # Force to install the latest version.
-      system "brew cask install #{options.install_options} #{app[:token]} --force"
+      system "brew cask install #{options.install_options} #{app[:token]} --force " + verbose_flag
 
       # Remove the old versions.
       app[:current].each do |version|
@@ -92,7 +99,7 @@ module Bcu
       end
     end
 
-    system "brew cleanup" if options.cleanup && cleanup_necessary
+    system "brew cleanup " + verbose_flag if options.cleanup && cleanup_necessary
   end
 
   def self.find_outdated_apps(quiet)

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -13,6 +13,7 @@ module Bcu
     options.force_yes = false
     options.no_brew_update = false
     options.quiet = false
+    options.verbose = false
     options.install_options = ""
     options.list_pinned = false
     options.pin = nil
@@ -62,6 +63,10 @@ module Bcu
         options.quiet = true
       end
 
+      opts.on("-v", "--verbose", "Make output more verbose") do
+        options.verbose = true
+      end
+
       opts.on("--no-quarantine", "Add --no-quarantine option to install command, see brew cask documentation for additional information") do
         options.install_options += " --no-quarantine"
       end
@@ -80,6 +85,12 @@ module Bcu
     end
 
     parser.parse!(args)
+
+    # verbose and quiet cannot both exist
+    if options.quiet and options.verbose
+      onoe "--quiet and --verbose cannot be specified at the same time"
+      exit 1
+    end
 
     options.casks = args
 

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -87,7 +87,7 @@ module Bcu
     parser.parse!(args)
 
     # verbose and quiet cannot both exist
-    if options.quiet and options.verbose
+    if options.quiet && options.verbose
       onoe "--quiet and --verbose cannot be specified at the same time"
       exit 1
     end

--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -52,7 +52,11 @@ module Cask
     Dir["#{CASKROOM}/#{token}/*"].map { |e| File.basename e }
   end
 
-  def self.brew_update
-    SystemCommand.run(HOMEBREW_BREW_FILE, args: ["update"], print_stderr: true, print_stdout: false)
+  def self.brew_update(verbose)
+    if verbose
+      SystemCommand.run(HOMEBREW_BREW_FILE, args: ["update", "--verbose"], print_stderr: true, print_stdout: true)
+    else
+      SystemCommand.run(HOMEBREW_BREW_FILE, args: ["update"], print_stderr: true, print_stdout: false)
+    end
   end
 end


### PR DESCRIPTION
Adding the `-v` or `--verbose` option to make output more verbose.
Cannot specify `--verbose` and `--quiet` at the same time.
Specifying `--verbose` will pass the same option to `brew update`, `brew cask install` and `brew cleanup`, causing them to generate verbose output.
This can be very useful in several ways, like viewing update progress, viewing downloading speed during install, and to let users see what files are being cleaned.
In fact, I always use `brew update -v` instead of `brew update` because my network is not very fast and I hate seeing the command stuck at blank output. I wish `brew cu` can have a similar function.