### PR TITLE
Shell-escape an argument to system

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -6,6 +6,7 @@ require "extend/formatter"
 require "extend/cask"
 require "fileutils"
 require "set"
+require "shellwords"
 
 module Bcu
   PINS_FILE = File.expand_path(File.dirname(__FILE__) + "/../pinned")
@@ -94,7 +95,7 @@ module Bcu
       # Remove the old versions.
       app[:current].each do |version|
         unless version == "latest"
-          system "rm -rf #{CASKROOM}/#{app[:token]}/#{version}"
+          system "rm -rf #{CASKROOM}/#{app[:token]}/#{Shellwords.escape(version)}"
         end
       end
     end


### PR DESCRIPTION
Hi,

I tried my hand at fixing the issue I raised with the Ruby `Shellwords` module.

Thanks for making homebrew-cask-upgrade!

---

Commit message:

This commit fixes #145, where the version number argument was not being escaped before being passed to `system`, which resulted in a syntax error from `sh` if the version number contained punctuation or other shell characters.