### PR TITLE
Including Mac AppStore applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,20 @@ Options:
     -q, --quiet           Do not show information about installed apps or current options.
     -v, --verbose         Make output more verbose.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
-    -i, --interactive     Running update in interactive mode    
+    -i, --interactive     Running update in interactive mode
+        --include-mas     (Experimental) Include applications from Mac App Store.    
 ```
 
 Display usage instructions:
 ```sh
 brew help cu
 ```
+
+### Mac App Store applications (Experimental)
+By adding `--include-mas` parameter to the `brew cu` command, we use [mas](https://github.com/mas-cli/mas/) cli tool to manage
+upgrades for Mac App Store applications as well.
+
+**Note:** This feature is highly experimental and we don't guarantee it's functionality. Use at your own risk. 
 
 ### Interactive mode
 

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -51,6 +51,9 @@
 #:    If `--no-quarantine` is passed, that option will be added to the install
 #:    command (see `man brew-cask` for reference)
 #:
+#:    If `--include-mas` is passed, command will include Mac App Store apps
+#:    in the result. It uses mas/mas-cli for such functionality.
+#:
 #:`INTERACTIVE MODE`:
 #:    After listing casks to upgrade you want those casks to be upgraded.
 #:    By using the option `i` you will step into an interactive mode.

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -15,9 +15,9 @@ module Bcu
     def run_process(options)
       unless options.quiet
         ohai "Options"
-        puts_stdout_or_stderr "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
-        puts_stdout_or_stderr "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
-        puts_stdout_or_stderr "Include mac app store (--include-mas): #{Formatter.colorize(options.include_mas, options.include_mas ? "green" : "red")}" if options.include_mas
+        puts "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
+        puts "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
+        puts "Include mac app store (--include-mas): #{Formatter.colorize(options.include_mas, options.include_mas ? "green" : "red")}" if options.include_mas
       end
 
       unless options.no_brew_update

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -113,10 +113,14 @@ module Bcu
         input = $stdin.gets.strip
 
         if input.casecmp("p").zero?
-          cmd = Bcu::Pin::Add.new
-          args = []
-          args[1] = app[:token]
-          cmd.process args, options
+          if app[:mas]
+            onoe "Pinning is not yet supported for MAS applications."
+          else
+            cmd = Bcu::Pin::Add.new
+            args = []
+            args[1] = app[:token]
+            cmd.process args, options
+          end
         end
 
         # rubocop:disable Rails/Exit

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -90,7 +90,7 @@ module Bcu
         mas_cask = {
           cask:         nil,
           name:         data[2],
-          token:        "#{token} ",
+          token:        token,
           version:      new_version.nil? ? data[3] : new_version,
           current:      data[3],
           outdated?:    !new_version.nil?,

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -15,10 +15,9 @@ module Bcu
     def run_process(options)
       unless options.quiet
         ohai "Options"
-        puts "Include auto-update (-a): #{Formatter.colorize(options.all,
-                                                             options.all ? "green" : "red")}"
-        puts "Include latest (-f): #{Formatter.colorize(options.force,
-                                                        options.force ? "green" : "red")}"
+        puts_stdout_or_stderr "Include auto-update (-a): #{Formatter.colorize(options.all, options.all ? "green" : "red")}"
+        puts_stdout_or_stderr "Include latest (-f): #{Formatter.colorize(options.force, options.force ? "green" : "red")}"
+        puts_stdout_or_stderr "Include mac app store (--include-mas): #{Formatter.colorize(options.include_mas, options.include_mas ? "green" : "red")}" if options.include_mas
       end
 
       unless options.no_brew_update
@@ -27,6 +26,9 @@ module Bcu
       end
 
       installed = Cask.installed_apps(options)
+      if options.include_mas
+        include_mas_applications installed
+      end
 
       ohai "Finding outdated apps"
       outdated, state_info = find_outdated_apps(installed, options)
@@ -73,6 +75,29 @@ module Bcu
     end
 
     private
+
+    def self.include_mas_applications(installed)
+      result = IO.popen(%w(mas list)).read
+      mac_apps = result.split("\n")
+
+      mac_apps.each do |app|
+        data = app.split(/^(\d+) (.+) \((.+)\)$/)
+        mas_cask = {
+          :cask         => nil,
+          :name         => data[2],
+          :token        => data[2].downcase,
+          :version      => data[3],
+          :current      => [data[3]],
+          :outdated?    => false,
+          :auto_updates => true,
+          :mas          => true,
+          :mas_id       => data[1],
+        }
+        installed.push(mas_cask)
+      end
+
+      installed.sort_by! { |cask| cask[:token] }
+    end
 
     def to_upgrade_interactively(outdated, options, state_info)
       for_upgrade = []

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -103,6 +103,14 @@ module Bcu
         options.command = "unpin"
       end
 
+      opts.on("--include-mas", "Include Mac AppStore applications") do
+        if IO.popen(%w[which mas])).read.empty?
+          onoe "In order to use --include-mas the mas-cli has to be installed. Please see the instructions here: https://github.com/mas-cli/mas"
+          exit 1
+        end
+        options.include_mas = true
+      end
+
       opts.on("--report-only", "Only report casks to update with exit code") do
         options.report_only = true
       end
@@ -122,14 +130,6 @@ module Bcu
           options.backup_filename = filename
           options.command = "load"
         end
-      end
-
-      opts.on("--include-mas", "Include Mac AppStore applications") do
-        if IO.popen(%w(which mas)).read.empty?
-          onoe "In order to use --include-mas the mas-cli has to be installed. Please see the instructions here: https://github.com/mas-cli/mas"
-          exit 1
-        end
-        options.include_mas = true
       end
     end
 

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -104,7 +104,7 @@ module Bcu
       end
 
       opts.on("--include-mas", "Include Mac AppStore applications") do
-        if IO.popen(%w[which mas])).read.empty?
+        if IO.popen(%w[which mas]).read.empty?
           onoe "In order to use --include-mas the mas-cli has to be installed. Please see the instructions here: https://github.com/mas-cli/mas"
           exit 1
         end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -10,7 +10,7 @@ module Bcu
   def self.parse!(args)
     options_struct = Struct.new(:all, :force, :casks, :cleanup, :force_yes, :no_brew_update, :quiet, :verbose,
                                 :install_options, :list_pinned, :pin, :unpin, :interactive, :command, :report_only,
-                                :backup_filename, :debug)
+                                :backup_filename, :debug, :include_mas)
     options = options_struct.new
     options.all = false
     options.force = false
@@ -29,6 +29,7 @@ module Bcu
     options.command = "run"
     options.backup_filename = ""
     options.debug = false
+    options.include_mas = false
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -121,6 +122,14 @@ module Bcu
           options.backup_filename = filename
           options.command = "load"
         end
+      end
+
+      opts.on("--include-mas", "Include Mac AppStore applications") do
+        if IO.popen(%w(which mas)).read.empty?
+          onoe "In order to use --include-mas the mas-cli has to be installed. Please see the instructions here: https://github.com/mas-cli/mas"
+          exit 1
+        end
+        options.include_mas = true
       end
     end
 

--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -30,6 +30,7 @@ module Cask
           homepage:           cask.homepage,
           installed_versions: versions,
           tap:                cask.tap&.name,
+          mas:                false,
         }
       rescue CaskUnavailableError
         {
@@ -45,6 +46,7 @@ module Cask
           homepage:           nil,
           installed_versions: versions,
           tap:                nil,
+          mas:                false,
         }
       end
     end

--- a/lib/extend/formatter.rb
+++ b/lib/extend/formatter.rb
@@ -148,7 +148,11 @@ module Formatter
 
       row = []
       row << self::TableColumn.new(value: "#{(i+1).to_s.rjust(apps.length.to_s.length)}/#{apps.length}")
-      row << self::TableColumn.new(value: app[:token], color: color)
+      if app[:mas]
+        row << self::TableColumn.new(value: "#{app[:token]} ", color: color)
+      else
+        row << self::TableColumn.new(value: app[:token], color: color)
+      end
       if options.verbose
         row << self::TableColumn.new(value: app[:current_full])
         row << self::TableColumn.new(value: app[:version_full], color: "magenta")

--- a/lib/extend/formatter.rb
+++ b/lib/extend/formatter.rb
@@ -148,11 +148,8 @@ module Formatter
 
       row = []
       row << self::TableColumn.new(value: "#{(i+1).to_s.rjust(apps.length.to_s.length)}/#{apps.length}")
-      if app[:mas]
-        row << self::TableColumn.new(value: "#{app[:token]} ", color: color)
-      else
-        row << self::TableColumn.new(value: app[:token], color: color)
-      end
+      cask_column_value = app[:mas] ? "#{app[:token]} " : app[:token]
+      row << self::TableColumn.new(value: cask_column_value, color: color)
       if options.verbose
         row << self::TableColumn.new(value: app[:current_full])
         row << self::TableColumn.new(value: app[:version_full], color: "magenta")


### PR DESCRIPTION
Closes #152 

This PR adds an ability to update Mac AppStore apps through `brew cu` command.

- [x] Adding long option (`--include-mas`)
- [ ] Adding short option ??
- [x] Listing mac AppStore apps in the list
- [x] Adding check for existing setup for `mas-cli`
- [x] Updating MAS apps using `mas-cli` - currently doesn't work because of https://github.com/mas-cli/mas/issues/248
- [x] Adding documentation into `README.md`
- [ ] Adding documentation for the option