### PR TITLE
Fixing rubocop offences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ before_install:
   - gem install activesupport -v 5.2.4.1
   - mkdir -p /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
   - cp -rf . /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
-  - cd /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
+  - cd /usr/local/Homebrew/Library/Homebrew
 
 script:
+  - cd /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
+  - rubocop --version
   - rubocop
   - brew cu -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 os: osx
 
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - 2.7
@@ -16,9 +15,10 @@ before_install:
   - mkdir -p /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
   - cp -rf . /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
   - cd /usr/local/Homebrew/Library/Homebrew
+  - gem install bundler:1.17.2
 
 script:
   - cd /usr/local/Homebrew/Library/Taps/buo/homebrew-cask-upgrade
   - rubocop --version
   - rubocop
-  - brew cu -y
+  - brew cu -y --no-brew-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 os: osx
 
 rvm:
-  - 2.5
+  # - 2.5
   - 2.6
-  - 2.7
+  # - 2.7
 
 before_install:
   - brew update

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew cu [CASK]
 While running the `brew cu` command without any other further options, the script automatically runs `brew update` to get
 latest versions of all the installed casks (this can be disabled, see options below).
 
-It is also possible to use `*` to instal multiple casks at once, i.e. `brew cu flash-*` to install all casks starting with `flash-` prefix.
+It is also possible to use `*` to install multiple casks at once, i.e. `brew cu flash-*` to install all casks starting with `flash-` prefix.
 
 [![asciicast](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW.png)](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW)
 

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -47,7 +47,10 @@ module Bcu
         options.force = true
       end
 
-      opts.on("--no-brew-update", "Prevent auto-update of Homebrew, taps, and formulae before checking outdated apps") do
+      opts.on(
+        "--no-brew-update",
+        "Prevent auto-update of Homebrew, taps, and formulae before checking outdated apps",
+      ) do
         options.no_brew_update = true
       end
 
@@ -67,7 +70,10 @@ module Bcu
         options.verbose = true
       end
 
-      opts.on("--no-quarantine", "Add --no-quarantine option to install command, see brew cask documentation for additional information") do
+      opts.on(
+        "--no-quarantine",
+        "Add --no-quarantine option to install command, see brew cask documentation for additional information",
+      ) do
         options.install_options += " --no-quarantine"
       end
 


### PR DESCRIPTION
This PR is fixing a master branch rubocop offenses. Also due to changed requirements we're officially dropping support for ruby 2.4 as the gems are not compatible any more.