### PR TITLE
Update bcu.rb to require "cask", not "cask/all"

### DIFF
--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift("#{HOMEBREW_REPOSITORY}/Library/Homebrew/cask/lib")
 
 require "bcu/options"
 require "bcu/command/all"
-require "cask/all"
+require "cask"
 require "extend/formatter"
 require "extend/cask"
 require "extend/version"


### PR DESCRIPTION
Homebrew/brew#8262 moved `cask/all` to `cask`, which breaks this command. This change fixes it.