### PR TITLE
Use `brew reinstall` instead of deprecated `brew cask reinstall`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 *.gem
 pinned
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+*.iml
 *.gem
 pinned

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -85,7 +85,7 @@ module Bcu
 
       begin
         # Force to install the latest version.
-        cmd = "brew cask reinstall #{options.install_options} #{app[:token]} --force " + verbose_flag
+        cmd = "brew reinstall #{options.install_options} #{app[:token]} --force " + verbose_flag
         success = system "#{cmd}"
       rescue
         success = false


### PR DESCRIPTION
### Description
Fixes deprecation (in `master` branch) of `brew cask reinstall` in favour of `brew reinstall`. 

CC: @Amorymeltzer