### PR TITLE
Using persistent config file for execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Options:
     -q, --quiet           Do not show information about installed apps or current options.
     -v, --verbose         Make output more verbose.
         --no-quarantine   Pass --no-quarantine option to `brew cask install`.
-    -i, --interactive     Running update in interactive mode    
+    -i, --interactive     Running update in interactive mode
+    --ignore-config       Ignores any changes made to a default config    
 ```
 
 Display usage instructions:
@@ -94,3 +95,22 @@ For every cask it is then possible to use following options:
 
 Pinned apps will not be updated by `brew cu` until they are unpinned.
 NB: version pinning in `brew cu` will not prevent `brew cask upgrade` from updating pinned apps.
+
+### Default config
+
+In order to have less verbose execution, it is possible to alter default config under which the upgrade gets executed.
+That could be done by changing `~/.brew-cu` config file.
+This is the default config setting the default options:
+```yaml
+---
+all: false
+force: false
+cleanup: false
+force_yes: false
+no_brew_update: false
+quiet: false
+verbose: false
+interactive: false
+```
+
+If any changes to this config were made, those changes can be ignored by passing `--ignore-config` option.

--- a/brew-cask-upgrade.gemspec
+++ b/brew-cask-upgrade.gemspec
@@ -1,14 +1,15 @@
 Gem::Specification.new do |s|
-  s.name        = "brew-cask-upgrade"
-  s.version     = "2.0.1"
-  s.summary     = "A command line tool for Homebrew Cask"
+  s.name = "brew-cask-upgrade"
+  s.version = "2.0.1"
+  s.summary = "A command line tool for Homebrew Cask"
   s.description = "A command line tool for upgrading every outdated app installed by Homebrew Cask"
-  s.authors     = ["buo"]
-  s.email       = "buo@users.noreply.github.com"
-  s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  s.homepage    = "https://github.com/buo/homebrew-cask-upgrade"
-  s.license     = "MIT"
+  s.authors = ["buo"]
+  s.email = "buo@users.noreply.github.com"
+  s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.homepage = "https://github.com/buo/homebrew-cask-upgrade"
+  s.license = "MIT"
+  s.required_ruby_version = 2.6
 
-  s.bindir      = "bin"
+  s.bindir = "bin"
   s.executables = %w[brew-cask-upgrade]
 end

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -48,6 +48,8 @@
 #:    If `--no-quarantine` is passed, that option will be added to the install
 #:    command (see `man brew-cask` for reference)
 #:
+#:    If `--ignore-config` is passed, changes to user config file fill be ignored.
+#:
 #:`INTERACTIVE MODE`:
 #:    After listing casks to upgrade you want those casks to be upgraded.
 #:    By using the option `i` you will step into an interactive mode.

--- a/lib/bcu/command/pin_list.rb
+++ b/lib/bcu/command/pin_list.rb
@@ -21,7 +21,7 @@ module Bcu
       def add_cask(cask_name, casks)
         casks.push Cask.load_cask(cask_name)
       rescue Cask::CaskUnavailableError
-        Bcu::Pin::Remove.remove_pin cask_name
+        Bcu::Pin::Remove.remove_pin cask:cask_name
       end
     end
   end

--- a/lib/bcu/command/pin_remove.rb
+++ b/lib/bcu/command/pin_remove.rb
@@ -8,12 +8,12 @@ module Bcu
         # TODO: If we used deprecated --pin option, the value is not any more in the args
         pin = options.unpin if pin.nil?
 
-        remove_pin pin
+        remove_pin cask:pin
       end
 
       private
 
-      def remove_pin(cask, quiet = false)
+      def remove_pin(cask:, quiet: false)
         unless Pin.pinned.include? cask
           puts "Not pinned: #{Tty.green}#{cask}#{Tty.reset}" unless quiet
           return

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -32,7 +32,7 @@ module Bcu
         printf "Do you want to upgrade %<count>d app%<s>s or enter [i]nteractive mode [y/i/N]? ",
                count: outdated.length,
                s:     (outdated.length > 1) ? "s" : ""
-        input = STDIN.gets.strip
+        input = $stdin.gets.strip
 
         if input.casecmp("i").zero?
           options.interactive = true
@@ -60,7 +60,7 @@ module Bcu
         formatting = Formatter.formatting_for_app(state_info, app, options)
         printf 'Do you want to upgrade "%<app>s" or [p]in it to exclude it from updates [y/p/N]? ',
                app: Formatter.colorize(app[:token], formatting[0])
-        input = STDIN.gets.strip
+        input = $stdin.gets.strip
 
         if input.casecmp("p").zero?
           cmd = Bcu::Pin::Add.new
@@ -74,19 +74,17 @@ module Bcu
 
       ohai "Upgrading #{app[:token]} to #{app[:version]}"
       installation_successful = install app, options
-
-      if installation_successful
-        installation_cleanup app, options
-      end
+      installation_cleanup app, options if installation_successful
     end
 
     def install(app, options)
       verbose_flag = options.verbose ? "--verbose" : ""
+      debug_flag = options.debug ? "--debug" : ""
 
       begin
         # Force to install the latest version.
-        cmd = "brew reinstall #{options.install_options} #{app[:token]} --force " + verbose_flag
-        success = system "#{cmd}"
+        cmd = "brew reinstall #{options.install_options} #{app[:token]} --force #{verbose_flag} #{debug_flag}"
+        success = system cmd
       rescue
         success = false
       end
@@ -116,8 +114,7 @@ module Bcu
         end
 
         if installed.empty?
-          print_install_empty_message options.casks
-          exit 1
+          odie empty_message(options.casks)
         end
       end
 
@@ -147,15 +144,15 @@ module Bcu
       [outdated, state_info]
     end
 
-    def print_install_empty_message(cask_searched)
+    def empty_message(cask_searched)
       if cask_searched.length == 1
         if cask_searched[0].end_with? "*"
-          onoe "#{Tty.red}No Cask matching \"#{cask_searched[0]}\" is installed.#{Tty.reset}"
+          "#{Tty.red}No Cask matching \"#{cask_searched[0]}\" is installed.#{Tty.reset}"
         else
-          onoe "#{Tty.red}Cask \"#{cask_searched[0]}\" is not installed.#{Tty.reset}"
+          "#{Tty.red}Cask \"#{cask_searched[0]}\" is not installed.#{Tty.reset}"
         end
       else
-        onoe "#{Tty.red}No casks matching your arguments found.#{Tty.reset}"
+        "#{Tty.red}No casks matching your arguments found.#{Tty.reset}"
       end
     end
   end

--- a/lib/bcu/module/pin.rb
+++ b/lib/bcu/module/pin.rb
@@ -1,6 +1,6 @@
 module Bcu
   module Pin
-    PINS_FILE = File.expand_path(File.dirname(__FILE__) + "/../../../pinned")
+    PINS_FILE = File.expand_path(File.dirname(__FILE__) + "/../../../pinned").freeze
 
     module_function
 

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -6,26 +6,18 @@ module Bcu
   end
 
   def self.parse!(args)
-    options_struct = Struct.new(:all, :force, :casks, :cleanup, :force_yes, :no_brew_update, :quiet, :verbose,
-                                :install_options, :list_pinned, :pin, :unpin, :interactive, :command)
-    options = options_struct.new
-    options.all = false
-    options.force = false
-    options.casks = nil
-    options.cleanup = false
-    options.force_yes = false
-    options.no_brew_update = false
-    options.quiet = false
-    options.verbose = false
-    options.install_options = ""
-    options.list_pinned = false
-    options.pin = nil
-    options.unpin = nil
-    options.interactive = false
-    options.command = "run"
+    options = build_config
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
+
+      opts.on("--ignore-config") do
+        options = build_config false
+      end
+
+      opts.on("--debug") do
+        options.debug = true
+      end
 
       # Prevent using short -p syntax for pinning
       opts.on("-p") do
@@ -125,5 +117,82 @@ module Bcu
       onoe "--quiet and --verbose cannot be specified at the same time"
       exit 1
     end
+  end
+
+  def self.build_config(use_config_file = true)
+    if use_config_file
+      options = load_default_options
+    else
+      options = create_default_options
+    end
+    options.casks = nil
+    options.install_options = ""
+    options.list_pinned = false
+    options.pin = nil
+    options.unpin = nil
+    options.command = "run"
+
+    options
+  end
+
+  def self.load_default_options
+    config_filename = "#{ENV["HOME"]}/.brew-cu"
+    unless File.exist?(config_filename)
+      odebug "Config file doesn't exist, creating"
+      create_default_config_file config_filename
+    end
+
+    default_options = create_default_options
+    if File.exist?(config_filename)
+      odebug "Loading configuration from config file"
+      handle = File.open(config_filename)
+      options = YAML::load handle.read
+      odebug "Configuration loaded", options
+      OpenStruct.new(options.to_h)
+    else
+      # something went wrong while reading config file
+      odebug "Config file wasn't created, setting default config"
+      default_options
+    end
+  end
+
+  def self.create_default_options
+    default_values = default_config_hash
+    default_options = OpenStruct.new
+    default_options.all = default_values["all"]
+    default_options.force = default_values["force"]
+    default_options.cleanup = default_values["cleanup"]
+    default_options.force_yes = default_values["force_yes"]
+    default_options.no_brew_update = default_values["no_brew_update"]
+    default_options.quiet = default_values["quiet"]
+    default_options.verbose = default_values["verbose"]
+    default_options.interactive = default_values["interactive"]
+    default_options.debug = default_values["debug"]
+    default_options
+  end
+
+  def self.create_default_config_file(config_filename)
+    begin
+      system "touch #{config_filename}"
+      handle = File.open(config_filename, "w")
+      handle.write default_config_hash.to_yaml
+      handle.close
+    rescue Exception => e
+      odebug "RESCUE: File couldn't be created", e
+      system "rm -f #{config_filename}"
+    end
+  end
+
+  def self.default_config_hash
+    {
+        "all" => false,
+        "force" => false,
+        "cleanup" => false,
+        "force_yes" => false,
+        "no_brew_update" => false,
+        "quiet" => false,
+        "verbose" => false,
+        "interactive" => false,
+    }
   end
 end

--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -1,6 +1,6 @@
 # For backward-compatibility
 # See https://github.com/buo/homebrew-cask-upgrade/issues/97
-CASKROOM = Cask.methods.include?(:caskroom) ? Cask.caskroom : Cask::Caskroom.path
+CASKROOM = Cask.methods.include?(:caskroom) ? Cask.caskroom.freeze : Cask::Caskroom.path.freeze
 
 module Cask
   def self.installed_apps


### PR DESCRIPTION
### Description
In order to allow changing default configuration for user execution, the default config is stored in user home directory.
Any additional options passed to the command have preference.

Closes #156 

### Actions taken
- storing default execution configuration in user home
- adding option to ignore changes made to user config
- updating README
- fixing rubocop offenses

CC: @muescha