### PR TITLE
Add batched update option for interactive mode

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -63,10 +63,12 @@ module Bcu
       end
 
       # upgrade deferred applications
+      tmp_flag = options.interactive
       options.interactive = false
       batched.each do |app|
         upgrade app, options, state_info
       end
+      options.interactive = tmp_flag
 
       system "brew", "cleanup", options.verbose ? "--verbose": "" if options.cleanup && cleanup_necessary
     end


### PR DESCRIPTION
This PR add support for batched update option for interactive mode. 

To be specific, I add option `b` for each interaction. And for each app answered with `b`, I record it in a temporary list, then perform upgrade after all interactions are answered.

Fixes https://github.com/buo/homebrew-cask-upgrade/issues/182 (asks for the same feature enhancement) 