### PR TITLE
Add options to export pins into file and load it back

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,17 @@ For every cask it is then possible to use following options:
 
 Pinned apps will not be updated by `brew cu` until they are unpinned.
 NB: version pinning in `brew cu` will not prevent `brew cask upgrade` from updating pinned apps.
+
+### Export / Import pinned apps
+
+In order to export backup you pinned casks into a file, simply pass `--export` option to the `pinned` command.
+```sh
+brew cu pinned --export my-backup-filename.txt
+```
+**Note**: Versions, in which were casks pinned, are not exported as it is nt possible to install a specific version afterwards. 
+
+In order to load the configuration back, use `--load` option.
+```sh
+brew cu pinned --load my-backup-filename.txt
+```
+**Note**: Loading the configuration will **replace** current values.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ NB: version pinning in `brew cu` will not prevent `brew cask upgrade` from updat
 
 ### Export / Import pinned apps
 
-In order to export backup you pinned casks into a file, simply pass `--export` option to the `pinned` command.
+In order to export backup of your pinned casks into a file, simply pass `--export` option to the `pinned` command.
 ```sh
 brew cu pinned --export my-backup-filename.txt
 ```
-**Note**: Versions, in which were casks pinned, are not exported as it is nt possible to install a specific version afterwards. 
+**Note**: Versions, in which were casks pinned, are not exported as it isn’t possible to install a specific version afterwards. 
 
 In order to load the configuration back, use `--load` option.
 ```sh

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -22,7 +22,9 @@
 #:      upgraded by `brew cu` command. See also `pin`.
 #:
 #:   `cu pinned`
-#:      Lists all CASKs that have been pinned.
+#:      Lists all CASKs that have been pinned. Add `--export FILENAME`
+#:      option to export the configuration to a file and `--load` to
+#:      load it back.
 #:
 #:`OPTIONS`:
 #:

--- a/lib/bcu.rb
+++ b/lib/bcu.rb
@@ -29,6 +29,8 @@ module Bcu
   # @return [Command]
   def self.resolve_command(options)
     return Bcu::Pin::List.new if options.command == "pinned"
+    return Bcu::Pin::Export.new if options.command == "export"
+    return Bcu::Pin::Load.new if options.command == "load"
     return Bcu::Pin::Add.new if options.command == "pin"
     return Bcu::Pin::Remove.new if options.command == "unpin"
     return Bcu::Livecheck.new if options.command == "livecheck"

--- a/lib/bcu/command/all.rb
+++ b/lib/bcu/command/all.rb
@@ -3,6 +3,8 @@
 require "#{File.dirname(__FILE__)}/command"
 require "#{File.dirname(__FILE__)}/livecheck"
 require "#{File.dirname(__FILE__)}/pin_add"
+require "#{File.dirname(__FILE__)}/pin_export"
 require "#{File.dirname(__FILE__)}/pin_list"
+require "#{File.dirname(__FILE__)}/pin_load"
 require "#{File.dirname(__FILE__)}/pin_remove"
 require "#{File.dirname(__FILE__)}/upgrade"

--- a/lib/bcu/command/pin_export.rb
+++ b/lib/bcu/command/pin_export.rb
@@ -6,7 +6,7 @@ module Bcu
   module Pin
     class Export < Command
       def process(_, options)
-        file_name = options.export_filename
+        file_name = options.backup_filename
         File.open(file_name, "w+") do |file|
           Pin.pinned.each do |cask_name|
             file.puts cask_name

--- a/lib/bcu/command/pin_export.rb
+++ b/lib/bcu/command/pin_export.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "bcu/module/pin"
+
+module Bcu
+  module Pin
+    class Export < Command
+      def process(_, options)
+        file_name = options.export_filename
+        File.open(file_name, "w+") do |file|
+          Pin.pinned.each do |cask_name|
+            file.puts cask_name
+          end
+        end
+        puts Formatter.success "Pins exported to #{file_name}"
+      end
+    end
+  end
+end

--- a/lib/bcu/command/pin_load.rb
+++ b/lib/bcu/command/pin_load.rb
@@ -6,7 +6,7 @@ module Bcu
   module Pin
     class Load < Command
       def process(_, options)
-        file_name = options.export_filename
+        file_name = options.backup_filename
         File.open(file_name, "r") do |source_file|
           File.open PINS_FILE, "w+" do |file|
             source_file.each_line do |cask|

--- a/lib/bcu/command/pin_load.rb
+++ b/lib/bcu/command/pin_load.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "bcu/module/pin"
+
+module Bcu
+  module Pin
+    class Load < Command
+      def process(_, options)
+        file_name = options.export_filename
+        File.open(file_name, "r") do |source_file|
+          File.open PINS_FILE, "w+" do |file|
+            source_file.each_line do |cask|
+              file.puts(cask.rstrip)
+            end
+          end
+        end
+        puts Formatter.success "Pins loaded from #{file_name}"
+      end
+    end
+  end
+end

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -10,7 +10,7 @@ module Bcu
   def self.parse!(args)
     options_struct = Struct.new(:all, :force, :casks, :cleanup, :force_yes, :no_brew_update, :quiet, :verbose,
                                 :install_options, :list_pinned, :pin, :unpin, :interactive, :command, :report_only,
-                                :export_filename)
+                                :backup_filename)
     options = options_struct.new
     options.all = false
     options.force = false
@@ -27,7 +27,7 @@ module Bcu
     options.interactive = false
     options.report_only = false
     options.command = "run"
-    options.export_filename = ""
+    options.backup_filename = ""
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -107,12 +107,12 @@ module Bcu
 
       if args[0] == "pinned"
         opts.on("--export FILENAME", "Filename for export") do |filename|
-          options.export_filename = filename
+          options.backup_filename = filename
           options.command = "export"
         end
 
         opts.on("--load FILENAME", "Source filename for loading pinned casks") do |filename|
-          options.export_filename = filename
+          options.backup_filename = filename
           options.command = "load"
         end
       end
@@ -121,7 +121,7 @@ module Bcu
     parser.parse!(args)
 
     if %w[pin unpin pinned livecheck run].include?(args[0])
-      options.command = args[0] if options.export_filename == ""
+      options.command = args[0] if options.backup_filename == ""
       validate_command_args args, options
     end
     validate_options options

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -9,7 +9,8 @@ module Bcu
 
   def self.parse!(args)
     options_struct = Struct.new(:all, :force, :casks, :cleanup, :force_yes, :no_brew_update, :quiet, :verbose,
-                                :install_options, :list_pinned, :pin, :unpin, :interactive, :command, :report_only)
+                                :install_options, :list_pinned, :pin, :unpin, :interactive, :command, :report_only,
+                                :export_filename)
     options = options_struct.new
     options.all = false
     options.force = false
@@ -26,6 +27,7 @@ module Bcu
     options.interactive = false
     options.report_only = false
     options.command = "run"
+    options.export_filename = ""
 
     parser = OptionParser.new do |opts|
       opts.banner = "Usage: brew cu [CASK] [options]"
@@ -102,12 +104,24 @@ module Bcu
       opts.on("--report-only", "Only report casks to update with exit code") do
         options.report_only = true
       end
+
+      if args[0] == "pinned"
+        opts.on("--export FILENAME", "Filename for export") do |filename|
+          options.export_filename = filename
+          options.command = "export"
+        end
+
+        opts.on("--load FILENAME", "Source filename for loading pinned casks") do |filename|
+          options.export_filename = filename
+          options.command = "load"
+        end
+      end
     end
 
     parser.parse!(args)
 
     if %w[pin unpin pinned livecheck run].include?(args[0])
-      options.command = args[0]
+      options.command = args[0] if options.export_filename == ""
       validate_command_args args, options
     end
     validate_options options


### PR DESCRIPTION
### Description
Adds options to `pinned` command to export casks to a given file name and then load it back.

### Actions taken
* add `--export` option (w/ filename argument)
* add `--load` option (w/ filename argument)

Fixes #208 