### PR TITLE
Make GitHub Actions to be read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 jobs:
   upgrade:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   upgrade:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions: read-all
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a job called "style-check"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,7 +10,8 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Make GitHub Actions to be read-only[0].

[0]https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>
