### PR TITLE
Batched interactive more

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -98,7 +98,6 @@ module Bcu
       for_upgrade
     end
 
-
     def upgrade(app, options)
       ohai "Upgrading #{app[:token]} to #{app[:version]}"
       installation_successful = install app, options


### PR DESCRIPTION
This is an alternative solution to https://github.com/buo/homebrew-cask-upgrade/pull/195 

### Description
Currently when upgrading in interactive mode, you need to interact for each cask and wait for (potential) update and then decide on the next one. 
With this change we change this behaviour to first decide on every outdated cask if we want to update that or not and then install them in one go.

### Actions taken
- [x] When interactive mode is selected, collect upgradeable casks first and install them.