### PR TITLE
Fix rubocop offenses

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -160,7 +160,7 @@ module Bcu
       ohai "Cleaning up old versions" if options.verbose
       # Remove the old versions.
       app[:installed_versions].each do |version|
-        system "rm", "-rf", "#{CASKROOM}/#{app[:token]}/#{Shellwords.escape(version)}" unless version == "latest"
+        system "rm", "-rf", "#{CASKROOM}/#{app[:token]}/#{Shellwords.escape(version)}" if version != "latest"
       end
     end
 

--- a/lib/extend/formatter.rb
+++ b/lib/extend/formatter.rb
@@ -88,10 +88,10 @@ module Formatter
         if th.align == "center"
           padding_left = padding / 2
           padding_right = padding - padding_left
-          padding_right += gutter unless i - 1 == cols
+          padding_right += gutter if i - 1 != cols
           output << "#{" " * padding_left}#{string}#{" " * padding_right}"
         else
-          padding += gutter unless i - 1 == cols
+          padding += gutter if i - 1 != cols
           output << "#{string}#{" " * padding}"
         end
       end
@@ -101,7 +101,7 @@ module Formatter
       rows.each do |row|
         row.each_with_index do |td, i|
           padding = col_widths[i] - td.value.length
-          padding += gutter unless i - 1 == cols
+          padding += gutter if i - 1 != cols
           output << "#{Tty.send(td.color)}#{td.value}#{Tty.reset}#{" " * padding}"
         end
         output << "\n"


### PR DESCRIPTION
If new rubocop offenses after changes in project configuraion.

### Fixed
- [x] Using `if` instead of `unless` 