### PR TITLE
Fix `undefined method versions for #<Cask`

### DIFF
--- a/lib/bcu/command/pin_add.rb
+++ b/lib/bcu/command/pin_add.rb
@@ -36,7 +36,7 @@ module Bcu
         end
 
         formatted_cask_name = "#{Tty.green}#{cask_name}#{Tty.reset}"
-        formatted_version = "#{Tty.magenta}#{cask.versions.first}#{Tty.reset}"
+        formatted_version = "#{Tty.magenta}#{cask.installed_version}#{Tty.reset}"
 
         puts "Pinned: #{formatted_cask_name} in version #{formatted_version}"
       end


### PR DESCRIPTION
fixes #231

To fix this error, I believe we should simply use the `Cask::Cask#installed_version` method instead of calling `.versions.first` on the `cask` variable in `Bcu::Pin::Add#run_add_pin`.

Here are the steps to reproduce+fix the issue on your side.
```shell
brew info --cask deepl
# ==> deepl: 4.5.542015 (auto_updates)
# https://www.deepl.com/
# /opt/homebrew/Caskroom/deepl/4.4.513804 (119B)

brew cu pin deepl
# Error: undefined method `versions' for #<Cask deepl>
```

At this stage, simply apply the fix to your local install of _homebrew-cask-upgrade_:

```shell
# macOS/BSD syntax
sed -i '' -E 's/(cask\.)versions\.first/\1installed_version/' \
  "$HOMEBREW_REPOSITORY/Library/Taps/buo/homebrew-cask-upgrade/lib/bcu/command/pin_add.rb"
```

Pinning should now be working again:

```shell
brew cu unpin deepl
# Unpinned: deepl

brew cu pin deepl
# Pinned: deepl in version 4.4.513804
```

(optionally) Clean your local install (which reverts to the broken version):
```shell
cd "$HOMEBREW_REPOSITORY/Library/Taps/buo/homebrew-cask-upgrade/" && git checkout -- .
```
