### PR TITLE
Fix latest version detection on casks with livecheck block

### DIFF
--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "livecheck/livecheck"
+
 # For backward-compatibility
 # See https://github.com/buo/homebrew-cask-upgrade/issues/97
 CASKROOM = (Cask.methods.include?(:caskroom) ? Cask.caskroom : Cask::Caskroom.path).freeze


### PR DESCRIPTION
Currently, for all casks with a `livecheck do` block (that are not in the main Cask repository), the latest version cannot be detected, even though it is present in `brew info`.
![CleanShot 2024-04-16 at 02 30 07@2x](https://github.com/buo/homebrew-cask-upgrade/assets/22275534/94b96eab-5307-4949-a9fe-a22a2f7f58f6)
(Note that [`font-sauce-code-pro-nerd-font.rb`](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-sauce-code-pro-nerd-font.rb) has a `livecheck do` block, while [`font-meslo-for-powerlevel10k.rb`](https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-meslo-for-powerlevel10k.rb) does not, even though they are both in Cask Fonts.)

Currently, the `load_cask` function (basically just `CaskLoader.load`) throws the following `CaskUnavailableError` error when facing such casks:
> Cask 'font-sauce-code-pro-nerd-font' is unreadable: uninitialized constant Livecheck::Formula

Adding a requires clause fixes this issue.