### PR TITLE
Accomodate for module change in upstream for ohai

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -4,6 +4,8 @@ require "bcu/module/pin"
 
 module Bcu
   class Upgrade < Command
+    include Utils::Output::Mixin
+
     def process(_args, options)
       return run_process(options) if $stdout.tty?
 


### PR DESCRIPTION
[homebrew/brew#20525](https://github.com/Homebrew/brew/pull/20525) changed the location of auxiliary logging functions like `ohai`, thus causing `brew cu` to throw the following error:
```
Error: undefined method 'ohai' for an instance of Bcu::Upgrade
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Taps/buo/homebrew-cask-upgrade/lib/bcu/command/upgrade.rb:17:in 'Bcu::Upgrade#run_process'
/opt/homebrew/Library/Taps/buo/homebrew-cask-upgrade/lib/bcu/command/upgrade.rb:8:in 'Bcu::Upgrade#process'
/opt/homebrew/Library/Taps/buo/homebrew-cask-upgrade/lib/bcu.rb:24:in 'Bcu.process'
/opt/homebrew/Library/Taps/buo/homebrew-cask-upgrade/cmd/brew-cu.rb:75:in '<main>'
<internal:/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
<internal:/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/gems/3.4.0/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
/opt/homebrew/Library/Homebrew/utils.rb:17:in 'block in Homebrew.require?'
/opt/homebrew/Library/Homebrew/warnings.rb:29:in 'Warnings.ignore'
/opt/homebrew/Library/Homebrew/utils.rb:16:in 'Homebrew.require?'
/opt/homebrew/Library/Homebrew/brew.rb:116:in '<main>'
If reporting this issue please do so at (not Homebrew/* repositories):
  https://github.com/buo/homebrew-cask-upgrade/issues/new
```
This PR thus adds an include to deal with the change.

Fixes #269.